### PR TITLE
qsc: Add Linux support

### DIFF
--- a/qsc/__init__.py
+++ b/qsc/__init__.py
@@ -33,7 +33,7 @@ LINBUILD_PATH = os.path.join(DATA_PATH, "linbuild.sh")
 
 # Settings
 REPO_BASE_URL = "https://download.qt.io/"
-REPO_SRC_PATH = "{0}/official_releases/qt/{1}/{2}/single/qt-everywhere-src-{2}.tar.xz"
+REPO_SRC_PATH = "{0}/official_releases/qt/{1}/{2}/single/qt-everywhere-opensource-src-{2}.tar.xz"
 REPO_JOM_PATH = "{0}/official_releases/jom/jom.zip"
 
 USE_CACHE = True

--- a/qsc/__init__.py
+++ b/qsc/__init__.py
@@ -29,7 +29,7 @@ WINBUILD_PATH = os.path.join(DATA_PATH, "winbuild.bat")
 
 # Settings
 REPO_BASE_URL = "https://download.qt.io/"
-REPO_SRC_PATH = "{0}/official_releases/qt/{1}/{2}/single/qt-everywhere-src-{2}.zip"
+REPO_SRC_PATH = "{0}/official_releases/qt/{1}/{2}/single/qt-everywhere-src-{2}.tar.xz"
 REPO_JOM_PATH = "{0}/official_releases/jom/jom.zip"
 
 USE_CACHE = True

--- a/qsc/__init__.py
+++ b/qsc/__init__.py
@@ -21,6 +21,9 @@ import platform
 def is_windows():
     return platform.system() == "Windows"
 
+def is_linux():
+    return platform.system() == "Linux"
+
 # Paths
 BASE_PATH = os.path.dirname(__file__)
 DATA_PATH = os.path.join(BASE_PATH, "data")

--- a/qsc/__main__.py
+++ b/qsc/__main__.py
@@ -114,6 +114,10 @@ if __name__ == "__main__":
         os.putenv("VS_EDITION", compiler["edition"])
         os.putenv("VCVARSALL", compiler.get("vcvarsall", ""))
         os.putenv("USE_VS", "1")
+    elif compiler["name"] == "gcc":
+        if not qsc.is_linux():
+            print("Only supported on Linux!")
+            exit(1)
     else:
         print("Unknown compiler '{}'".format(compiler.name))
         exit(1)

--- a/qsc/__main__.py
+++ b/qsc/__main__.py
@@ -176,6 +176,8 @@ if __name__ == "__main__":
     
     if qsc.is_windows():
         os.system(qsc.WINBUILD_PATH)
+    elif qsc.is_linux():
+        os.system(qsc.LINBUILD_PATH)
     else:
         print("Not supported yet, sorry :/")
         exit(1)

--- a/qsc/data/linbuild.sh
+++ b/qsc/data/linbuild.sh
@@ -1,5 +1,6 @@
+#!/bin/bash
 # QSC (Qt SDK Creator) - A tool for automatically downloading, building and stripping down Qt
-# Copyright (C) 2020 spycrab0
+# Copyright (C) 2020 OatmealDome
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -14,27 +15,15 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+set -e
 
-import os
-import platform
+../qt-everywhere-src-$RELEASE/configure \
+ -opensource -confirm-license \
+ -nomake examples -nomake tests \
+ $QT_CONFIGURE_OPTIONS \
+ -prefix $OUTNAME \
+ $QT_PLATFORM
 
-def is_windows():
-    return platform.system() == "Windows"
+make -j4
 
-def is_linux():
-    return platform.system() == "Linux"
-
-# Paths
-BASE_PATH = os.path.dirname(__file__)
-DATA_PATH = os.path.join(BASE_PATH, "data")
-
-WINBUILD_PATH = os.path.join(DATA_PATH, "winbuild.bat")
-LINBUILD_PATH = os.path.join(DATA_PATH, "linbuild.sh")
-
-# Settings
-REPO_BASE_URL = "https://download.qt.io/"
-REPO_SRC_PATH = "{0}/official_releases/qt/{1}/{2}/single/qt-everywhere-src-{2}.tar.xz"
-REPO_JOM_PATH = "{0}/official_releases/jom/jom.zip"
-
-USE_CACHE = True
-USE_JOM = True
+make install

--- a/qsc/download.py
+++ b/qsc/download.py
@@ -33,7 +33,7 @@ def download_file(url, path):
 
 def download_release(release):    
     url = source_url(release)
-    download_path = os.path.join("archives", "qt-everywhere-src-{}.tar.xz".format(release))
+    download_path = os.path.join("archives", "qt-everywhere-opensource-src-{}.tar.xz".format(release))
 
     print("Downloading Qt {}...".format(release), end="", flush=True)
     

--- a/qsc/download.py
+++ b/qsc/download.py
@@ -33,7 +33,7 @@ def download_file(url, path):
 
 def download_release(release):    
     url = source_url(release)
-    download_path = os.path.join("archives", "qt-everywhere-src-{}.zip".format(release))
+    download_path = os.path.join("archives", "qt-everywhere-src-{}.tar.xz".format(release))
 
     print("Downloading Qt {}...".format(release), end="", flush=True)
     

--- a/qsc/extract.py
+++ b/qsc/extract.py
@@ -23,7 +23,7 @@ import tarfile
 import qsc
 
 def extract_release(release):
-    name = "qt-everywhere-src-{}".format(release)
+    name = "qt-everywhere-opensource-src-{}".format(release)
 
     tar_path = os.path.join("archives", name+".tar.xz")
     

--- a/qsc/extract.py
+++ b/qsc/extract.py
@@ -18,14 +18,14 @@
 """Extracting archives and stuff"""
 
 import os
-import zipfile
+import tarfile
 
 import qsc
 
 def extract_release(release):
     name = "qt-everywhere-src-{}".format(release)
 
-    zip_path = os.path.join("archives", name+".zip")
+    tar_path = os.path.join("archives", name+".tar.xz")
     
     print("Extracting...", end="", flush=True)
     
@@ -33,7 +33,7 @@ def extract_release(release):
         print("Cached")
         return
     
-    with zipfile.ZipFile(zip_path, "r") as zip:
-        zip.extractall(".")
+    with tarfile.open(tar_path) as tar:
+        tar.extractall(".")
 
     print("Done")


### PR DESCRIPTION
Part of my efforts to get Dolphin running under the Steam Runtime. I used this tool to create a set of Qt 5 shared libraries.

Instead of downloading the zip, I changed it to download the tar.xz so that Unix permissions like +x stay intact (versus the zip which strips those). I think this should be fine on Windows too.